### PR TITLE
pps-test: line-flush stdout output

### DIFF
--- a/ppstest.c
+++ b/ppstest.c
@@ -118,6 +118,7 @@ retry:
 	       infobuf.assert_sequence,
 	       infobuf.clear_timestamp.tv_sec,
 	       infobuf.clear_timestamp.tv_nsec, infobuf.clear_sequence);
+	fflush(stdout);
 
 	return 0;
 }


### PR DESCRIPTION
Flush the stdout printing to make ppstest more useful in pipes chains.
Otherwise you need to wait awhile for the automatic flushing to kick in.

Signed-off-by: Ben Gardiner bengardiner@nanometrics.ca
