### PR TITLE
	add pps-tools.dirs to fix build error on debian squeeze

### DIFF
--- a/debian/pps-tools.dirs
+++ b/debian/pps-tools.dirs
@@ -1,0 +1,2 @@
+usr/include/sys/
+usr/bin/


### PR DESCRIPTION
```
newfile:    debian/pps-tools.dirs
```

Signed-off-by: Zhang, Guodong gdzhang@linx-info.com
