### PR TITLE
ppswatch: Add useful stats output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CFLAGS += -Wall -O2 -D_GNU_SOURCE
 CFLAGS += -I .
 CFLAGS += -ggdb
 CFLAGS += -D__N_PPS=18
+LDFLAGS += -lm
 
 # -- Actions section --
 


### PR DESCRIPTION
Calculate mean value and standard deviation of captured offsets. Display them at the exit.

Signed-off-by: Andrey Drobyshev <immortalguardian1@gmail.com>