### PR TITLE
Removes OFFSETASSERT requirement from ppstest and ppsctl.

### DIFF
--- a/ppsctl.c
+++ b/ppsctl.c
@@ -69,10 +69,6 @@ static int find_source(char *path, pps_handle_t *handle, int *avail_mode)
 		fprintf(stderr, "cannot CAPTUREASSERT\n");
 		return -1;
 	}
-	if ((*avail_mode & PPS_OFFSETASSERT) == 0) {
-		fprintf(stderr, "cannot OFFSETASSERT\n");
-		return -1;
-	}
 
 	return 0;
 }


### PR DESCRIPTION
There was a bizarre and undocumented 675ns offset being applied by
ppstest.  Any PPS offset is highly system-specific and doesn't belong
as a hardcoded constant in an application program.  In addition, at
least one PPS driver (pps-gmtimer) doesn't support OFFSETASSERT
(mainly as a defense against misguided programs such as this one), and
was unusable with ppstest due to the insistence of OFFSETASSERT.

This change:

1) Removes the OFFSETASSERT requirement from ppstest.

2) If the OFFSETASSERT capability exists, ppstest now uses it to clear
the offset, undoing any lingering offset from the old version.

3) Removes the OFFSETASSERT requirement from ppsctl.

TESTED:
Built and ran ppstest against both pps-gpio and pps-gmtimer on a
Beaglebone Black.
Built ppsctl.