### PR TITLE
Change bash dependency to sh

### DIFF
--- a/ppsfind
+++ b/ppsfind
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # ppsfind -- find pps device by name
 #
 # Copyright (C) 2005-2007   Rodolfo Giometti <giometti@linux.it>


### PR DESCRIPTION
I was having some issues using `ppsfind` on an embedded system where no Bash shell was included since the shebang in the file is `#!/bin/bash`. I've found that the script does not use any bash specific features so I suggest changing the shebang to `#!/bin/sh`.