### PR TITLE
Makefile: fix installation to empty DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ include .depend
 endif
 
 install : all
-	install -m 755 -t $(DESTDIR)/usr/bin ppsfind $(TARGETS)
-	install -m 644 -t $(DESTDIR)/usr/include/sys timepps.h
+	install -D -m 755 -t $(DESTDIR)/usr/bin ppsfind $(TARGETS)
+	install -D -m 644 -t $(DESTDIR)/usr/include/sys timepps.h
 
 uninstall :
 	for f in $(TARGETS); do rm $(DESTDIR)/usr/bin/$$f; done


### PR DESCRIPTION
When DESTDIR is empty, or at least does not contain usr/bin or
usr/include, the installation fails, because install does not create
those intermediate directories:

$ make DESTDIR=/tmp/koin install
install -m 755 -t /tmp/koin/usr/bin ppsfind ppstest ppsctl ppswatch ppsldisc
install: failed to access '/tmp/koin/usr/bin': No such file or directory

Using the -D option of install fixes this:

$ make DESTDIR=/tmp/koin install
install -D -m 755 -t /tmp/koin/usr/bin ppsfind ppstest ppsctl ppswatch ppsldisc
install -D -m 644 -t /tmp/koin/usr/include/sys timepps.h

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>