### PR TITLE
timepps: Ensure structs passed to kernel are zero initialized

### DIFF
--- a/timepps.h
+++ b/timepps.h
@@ -116,7 +116,7 @@ static __inline int time_pps_getparams(pps_handle_t handle,
 					pps_params_t *ppsparams)
 {
 	int ret;
-	struct pps_kparams __ppsparams;
+	struct pps_kparams __ppsparams = {};
 
 	ret = ioctl(handle, PPS_GETPARAMS, &__ppsparams);
 
@@ -133,7 +133,7 @@ static __inline int time_pps_getparams(pps_handle_t handle,
 static __inline int time_pps_setparams(pps_handle_t handle,
 					const pps_params_t *ppsparams)
 {
-	struct pps_kparams __ppsparams;
+	struct pps_kparams __ppsparams = {};
 
 	__ppsparams.api_version = ppsparams->api_version;
 	__ppsparams.mode = ppsparams->mode;
@@ -155,7 +155,7 @@ static __inline int time_pps_fetch(pps_handle_t handle, const int tsformat,
 					pps_info_t *ppsinfobuf,
 					const struct timespec *timeout)
 {
-	struct pps_fdata __fdata;
+	struct pps_fdata __fdata = {};
 	int ret;
 
 	/* Sanity checks */
@@ -167,7 +167,6 @@ static __inline int time_pps_fetch(pps_handle_t handle, const int tsformat,
 	if (timeout) {
 		__fdata.timeout.sec = timeout->tv_sec;
 		__fdata.timeout.nsec = timeout->tv_nsec;
-		__fdata.timeout.flags = ~PPS_TIME_INVALID;
 	} else
 		__fdata.timeout.flags = PPS_TIME_INVALID;
 
@@ -190,7 +189,7 @@ static __inline int time_pps_kcbind(pps_handle_t handle,
 					const int kernel_consumer,
 					const int edge, const int tsformat)
 {
-	struct pps_bind_args __bind_args;
+	struct pps_bind_args __bind_args = {};
 
 	__bind_args.tsformat = tsformat;
 	__bind_args.edge = edge;


### PR DESCRIPTION
Initialize all structs to zero to pass deterministic values to the
kernel. Also don't use ~PPS_TIME_INVALID to initialize
struct pps_fdata::timeout.flags, as this sets all currently undefined
bits.